### PR TITLE
widget: disable table header label selectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "egui-data-table"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-data-table"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/kang-sw/egui-data-table"
 authors = ["kang-sw"]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -33,7 +33,13 @@ impl RowViewer<Row> for Viewer {
     }
 
     fn column_name(&mut self, column: usize) -> Cow<'static, str> {
-        ["Name (Click To Sort)", "Age", "Is Student", "Grade"][column].into()
+        [
+            "Name (Click to sort)",
+            "Age",
+            "Is Student (Not sortable)",
+            "Grade",
+        ][column]
+            .into()
     }
 
     fn is_sortable_column(&mut self, column: usize) -> bool {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,6 +1,8 @@
 use std::mem::{replace, take};
 
-use egui::{Align, Color32, Event, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke};
+use egui::{
+    Align, Color32, Event, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke, Widget,
+};
 use egui_extras::Column;
 use tap::prelude::{Pipe, Tap};
 
@@ -127,7 +129,9 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
                                 ui.monospace(" ");
                             }
 
-                            ui.label(viewer.column_name(col.0));
+                            egui::Label::new(viewer.column_name(col.0))
+                                .selectable(false)
+                                .ui(ui);
                         });
 
                         painter = Some(ui.painter().clone());


### PR DESCRIPTION
Closes #10 

From the new egui widget focus priority logic(0.25 -> 0.27), table header cell's interaction priority became lower than its content, which resulting the label text selected prior to header cell selection.

As table cell interaction is required to sort each columns, this behavior is not more than just annoying. This PR simply makes table header's label content not selectable, which restores previous behavior.