### PR TITLE
Implement system clipboard support and TSV parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-08-18
+
+### Added
+
+- System clipboard support
+- New trait item: `Codec`
+
 ## [0.3.0] - 2024-07-04
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-data-table"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 repository = "https://github.com/kang-sw/egui-data-table"
 authors = ["kang-sw"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ egui_extras = { version = "0.28", default-features = false, features = [
 tap = "1"
 itertools = "0.13"
 serde = { version = "1", optional = true, features = ["derive"] }
+thiserror = "1"
 
 [dev-dependencies]
 eframe = { version = "0.28", features = ["serde", "persistence"] }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, iter::repeat_with};
 
 use egui::{Response, Sense, Widget};
 use egui_data_table::{
-    viewer::{default_hotkeys, CellWriteContext, UiActionContext},
+    viewer::{default_hotkeys, CellWriteContext, RowCodec, UiActionContext},
     RowViewer,
 };
 
@@ -25,9 +25,49 @@ enum Grade {
     F,
 }
 
+/* -------------------------------------------- Codec ------------------------------------------- */
+
+struct Codec;
+
+impl RowCodec<Row> for Codec {
+    type DeserializeError = &'static str;
+
+    fn encode_column(&mut self, src_row: &Row, column: usize, dst: &mut String) {
+        match column {
+            0 => dst.push_str(&src_row.0),
+            1 => dst.push_str(&src_row.1.to_string()),
+            2 => dst.push_str(&src_row.2.to_string()),
+            3 => dst.push_str(match src_row.3 {
+                Grade::A => "A",
+                Grade::B => "B",
+                Grade::C => "C",
+                Grade::F => "F",
+            }),
+            _ => unreachable!(),
+        }
+    }
+
+    fn decode_column(
+        &mut self,
+        src_data: &str,
+        column: usize,
+        dst_row: &mut Row,
+    ) -> Result<(), Self::DeserializeError> {
+        unimplemented!()
+    }
+}
+
 /* ------------------------------------ Viewer Implementation ----------------------------------- */
 
 impl RowViewer<Row> for Viewer {
+    fn try_create_codec(&mut self, is_encoding: bool) -> Option<impl RowCodec<Row>> {
+        if is_encoding {
+            Some(Codec)
+        } else {
+            None
+        }
+    }
+
     fn num_columns(&mut self) -> usize {
         4
     }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -80,7 +80,7 @@ impl RowCodec<Row> for Codec {
 /* ------------------------------------ Viewer Implementation ----------------------------------- */
 
 impl RowViewer<Row> for Viewer {
-    fn try_create_codec(&mut self, is_encoding: bool) -> Option<impl RowCodec<Row>> {
+    fn try_create_codec(&mut self, _: bool) -> Option<impl RowCodec<Row>> {
         Some(Codec)
     }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, iter::repeat_with};
 
 use egui::{Response, Sense, Widget};
 use egui_data_table::{
-    viewer::{default_hotkeys, CellWriteContext, RowCodec, UiActionContext},
+    viewer::{default_hotkeys, CellWriteContext, DecodeErrorBehavior, RowCodec, UiActionContext},
     RowViewer,
 };
 
@@ -52,8 +52,28 @@ impl RowCodec<Row> for Codec {
         src_data: &str,
         column: usize,
         dst_row: &mut Row,
-    ) -> Result<(), Self::DeserializeError> {
-        unimplemented!()
+    ) -> Result<(), DecodeErrorBehavior> {
+        match column {
+            0 => dst_row.0.replace_range(.., src_data),
+            1 => dst_row.1 = src_data.parse().map_err(|_| DecodeErrorBehavior::SkipRow)?,
+            2 => dst_row.2 = src_data.parse().map_err(|_| DecodeErrorBehavior::SkipRow)?,
+            3 => {
+                dst_row.3 = match src_data {
+                    "A" => Grade::A,
+                    "B" => Grade::B,
+                    "C" => Grade::C,
+                    "F" => Grade::F,
+                    _ => return Err(DecodeErrorBehavior::SkipRow),
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        Ok(())
+    }
+
+    fn create_empty_decoded_row(&mut self) -> Row {
+        Row("".to_string(), 0, false, Grade::F)
     }
 }
 
@@ -61,11 +81,7 @@ impl RowCodec<Row> for Codec {
 
 impl RowViewer<Row> for Viewer {
     fn try_create_codec(&mut self, is_encoding: bool) -> Option<impl RowCodec<Row>> {
-        if is_encoding {
-            Some(Codec)
-        } else {
-            None
-        }
+        Some(Codec)
     }
 
     fn num_columns(&mut self) -> usize {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -16,6 +16,7 @@ use self::state::*;
 use format as f;
 
 pub(crate) mod state;
+mod tsv;
 
 /* ------------------------------------------ Rendering ----------------------------------------- */
 
@@ -279,11 +280,14 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
                             Event::Copy => actions.push(UiAction::CopySelection),
                             Event::Cut => actions.push(UiAction::CutSelection),
 
-                            // TODO: Later try to parse clipboard contents and detect if
-                            // it's compatible with cells being pasted.
+                            // Try to parse clipboard contents and detect if it's compatible
+                            // with cells being pasted.
                             Event::Paste(clipboard) => {
                                 if !clipboard.is_empty() {
-                                    s.try_update_clipboard_from_system(viewer, clipboard);
+                                    // If system clipboard is not empty, try to update the internal
+                                    // clipboard with system clipboard content before applying
+                                    // paste operation.
+                                    s.try_update_clipboard_from_string(viewer, clipboard);
                                 }
 
                                 if i.modifiers.shift {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -281,7 +281,9 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
 
                             // TODO: Later try to parse clipboard contents and detect if
                             // it's compatible with cells being pasted.
-                            Event::Paste(_) => {
+                            Event::Paste(content) => {
+                                // Try to parse clipboard content as CSV.
+
                                 if i.modifiers.shift {
                                     actions.push(UiAction::PasteInsert)
                                 } else {

--- a/src/draw/state.rs
+++ b/src/draw/state.rs
@@ -1,5 +1,4 @@
 use std::{
-    cmp::Ordering,
     collections::{BTreeMap, BTreeSet, VecDeque},
     hash::{Hash, Hasher},
     mem::{replace, take},

--- a/src/draw/state.rs
+++ b/src/draw/state.rs
@@ -492,7 +492,14 @@ impl<R> UiState<R> {
             - If column count is larger than this, it is invalid data; we just skip parsing
         */
 
+        let Some(codec) = vwr.try_create_codec(false) else {
+            // Even when there is system clipboard content, we're going to ignore it and use
+            // internal clipboard if there's no way to parse it.
+            return false;
+        };
+
         // TODO: Update clipboard contents from system.
+        let view = tsv::ParsedTsv::parse(contents);
 
         // If any cell is failed to be parsed, we'll just give up all parsing then use internal
         // clipboard instead.
@@ -503,7 +510,7 @@ impl<R> UiState<R> {
         clipboard: &Clipboard<R>,
         vwr: &mut V,
     ) -> Option<String> {
-        // clipboard MUST be sorted before dumping.
+        // clipboard MUST be sorted before dumping; XXX: add assertion?
         #[allow(unused_mut)]
         let mut codec = vwr.try_create_codec(true)?;
 

--- a/src/draw/tsv.rs
+++ b/src/draw/tsv.rs
@@ -1,7 +1,29 @@
 //! A short implementation for reading and writing TSV data.
 
-pub struct TsvWriter<'a, W> {
-    writer: &'a mut W,
+pub fn write_tab(buf: &mut String) {
+    buf.push('\t');
+}
+
+pub fn write_newline(buf: &mut String) {
+    buf.push('\n');
+}
+
+pub fn write_content(buf: &mut String, mut item: &str) {
+    if item.is_empty() {
+        item = " ";
+    }
+
+    buf.reserve(item.len());
+
+    for char in item.chars() {
+        match char {
+            '\t' => buf.push_str(r"\t"),
+            '\n' => buf.push_str(r"\n"),
+            '\r' => buf.push_str(r"\r"),
+            '\\' => buf.push_str(r"\\"),
+            _ => buf.push(char),
+        }
+    }
 }
 
 /* ============================================================================================== */

--- a/src/draw/tsv.rs
+++ b/src/draw/tsv.rs
@@ -1,5 +1,7 @@
 //! A short implementation for reading and writing TSV data.
 
+use std::ops::Range;
+
 pub fn write_tab(buf: &mut String) {
     buf.push('\t');
 }
@@ -30,6 +32,167 @@ pub fn write_content(buf: &mut String, mut item: &str) {
 /*                                             READER                                             */
 /* ============================================================================================== */
 
-pub struct TsvReader<'a, R> {
-    reader: &'a mut R,
+pub struct ParsedTsv {
+    /// We need owned buffer to store escaped TSV data.
+    data: String,
+
+    /// Byte span info for each cell in the TSV data. As long as the cell is explicitly allocated
+    /// using tab character, the cell will be stored in this vector even if it is empty.
+    cell_spans: Vec<Range<u32>>,
+
+    /// Index offsets for start of each row in the `cell_spans` vector.
+    row_offsets: Vec<u32>,
+}
+
+impl ParsedTsv {
+    pub fn parse(data: &str) -> Self {
+        #[derive(Clone, Copy)]
+        enum ParseState {
+            Empty,
+            Escaping,
+        }
+
+        let mut s = Self {
+            data: Default::default(),
+            cell_spans: Default::default(),
+            row_offsets: Default::default(),
+        };
+
+        let mut state = ParseState::Empty;
+        let mut cell_start_char = 0;
+
+        // Add initial row offset.
+        s.row_offsets.push(0);
+
+        for char in data.chars() {
+            match state {
+                ParseState::Empty => match char {
+                    '\n' | '\t' => {
+                        if char == '\t' || cell_start_char != s.data.len() as u32 {
+                            // For tab character, we don't care if it's empty cell. Otherwise,
+                            // we add the last cell only when it's not empty.
+                            s.cell_spans.push(cell_start_char..s.data.len() as u32);
+                            cell_start_char = s.data.len() as _;
+                        }
+
+                        if char == '\n' {
+                            // Add row offset and move to new row.
+                            s.row_offsets.push(s.cell_spans.len() as _);
+                        }
+                    }
+                    '\r' => {
+                        // Ignoring.
+                    }
+                    '\\' => state = ParseState::Escaping,
+                    ch => s.data.push(ch),
+                },
+                ParseState::Escaping => {
+                    match char {
+                        't' => s.data.push('\t'),
+                        'n' => s.data.push('\n'),
+                        'r' => s.data.push('\r'),
+                        '\\' => s.data.push('\\'),
+                        ch => {
+                            // Just add the character as it is.
+                            s.data.push('\\');
+                            s.data.push(ch);
+                        }
+                    }
+
+                    state = ParseState::Empty;
+                }
+            }
+        }
+
+        // Need to check if we have any remaining cell to add.
+        {
+            if cell_start_char != s.data.len() as u32 {
+                s.cell_spans.push(cell_start_char..s.data.len() as u32);
+            }
+
+            if *s.row_offsets.last().unwrap() != s.cell_spans.len() as u32 {
+                s.row_offsets.push(s.cell_spans.len() as _);
+            }
+        }
+
+        // Optimize buffer usage.
+        s.data.shrink_to_fit();
+        s.cell_spans.shrink_to_fit();
+        s.row_offsets.shrink_to_fit();
+
+        s
+    }
+
+    pub fn num_columns_at(&self, row: usize) -> usize {
+        if row >= self.row_offsets.len() - 1 {
+            return 0;
+        }
+
+        let start = self.row_offsets[row] as usize;
+        let end = self.row_offsets[row + 1] as usize;
+
+        end - start
+    }
+
+    pub fn num_rows(&self) -> usize {
+        self.row_offsets.len() - 1
+    }
+
+    pub fn get_cell(&self, row: usize, column: usize) -> Option<&str> {
+        let row_offset = *self.row_offsets.get(row)? as usize;
+        let cell_span = self.cell_spans.get(row_offset + column)?;
+
+        Some(&self.data[cell_span.start as usize..cell_span.end as usize])
+    }
+
+    // TODO: Iterator function which returns (row, column, cell data) tuple.
+
+    pub fn iter_index_data(&self) -> impl Iterator<Item = (usize, usize, &str)> {
+        self.row_offsets
+            .windows(2)
+            .enumerate()
+            .flat_map(move |(row, range)| {
+                let (start, end) = (range[0] as usize, range[1] as usize);
+                (start..end).map(move |cell_offset| {
+                    let cell_span = self.cell_spans.get(cell_offset).unwrap();
+                    (
+                        row,
+                        cell_offset - start,
+                        &self.data[cell_span.start as usize..cell_span.end as usize],
+                    )
+                })
+            })
+    }
+}
+
+#[test]
+fn tsv_parsing() {
+    const TSV_DATA: &str = "Hello\tWorld\nThis\tIs\tA\tTest";
+
+    let parsed = ParsedTsv::parse(TSV_DATA);
+    assert_eq!(parsed.num_columns_at(0), 2);
+    assert_eq!(parsed.num_columns_at(1), 4);
+    assert_eq!(parsed.num_columns_at(2), 0);
+
+    assert_eq!(parsed.num_rows(), 2);
+
+    assert_eq!(parsed.get_cell(0, 0), Some("Hello"));
+    assert_eq!(parsed.get_cell(0, 1), Some("World"));
+    assert_eq!(parsed.get_cell(1, 0), Some("This"));
+    assert_eq!(parsed.get_cell(1, 1), Some("Is"));
+    assert_eq!(parsed.get_cell(1, 2), Some("A"));
+    assert_eq!(parsed.get_cell(1, 3), Some("Test"));
+    assert!(parsed.get_cell(1, 4).is_none());
+
+    assert_eq!(
+        parsed.iter_index_data().collect::<Vec<_>>(),
+        vec![
+            (0, 0, "Hello"),
+            (0, 1, "World"),
+            (1, 0, "This"),
+            (1, 1, "Is"),
+            (1, 2, "A"),
+            (1, 3, "Test"),
+        ]
+    );
 }

--- a/src/draw/tsv.rs
+++ b/src/draw/tsv.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 //! A short implementation for reading and writing TSV data.
 
 use std::ops::Range;

--- a/src/draw/tsv.rs
+++ b/src/draw/tsv.rs
@@ -1,0 +1,13 @@
+//! A short implementation for reading and writing TSV data.
+
+pub struct TsvWriter<'a, W> {
+    writer: &'a mut W,
+}
+
+/* ============================================================================================== */
+/*                                             READER                                             */
+/* ============================================================================================== */
+
+pub struct TsvReader<'a, R> {
+    reader: &'a mut R,
+}

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -4,6 +4,46 @@ use egui::{Key, KeyboardShortcut, Modifiers};
 pub use egui_extras::Column as TableColumnConfig;
 use tap::prelude::Pipe;
 
+/// A trait for encoding/decoding row data. Any valid UTF-8 string can be used for encoding,
+/// however, as csv is used for clipboard operations, it is recommended to serialize data in simple
+/// string format as possible.
+pub trait RowCodec<R>: 'static {
+    type DeserializeError;
+
+    /// Tries encode column data of given row into a string. As the cell for CSV row is already
+    /// occupied, if any error or unsupported data is found for that column, just empty out the
+    /// destination string buffer.
+    fn encode_column(&self, src_row: &R, column: usize, dst: &mut String);
+
+    /// Tries decode column data from a string into a row.
+    fn decode_column(
+        &self,
+        src_data: &str,
+        column: usize,
+        dst_row: &mut R,
+    ) -> Result<(), Self::DeserializeError>;
+}
+
+/// A placeholder codec for row viewers that not require serialization.
+impl<R> RowCodec<R> for () {
+    type DeserializeError = ();
+
+    fn encode_column(&self, src_row: &R, column: usize, dst: &mut String) {
+        let _ = (src_row, column, dst);
+        unimplemented!()
+    }
+
+    fn decode_column(
+        &self,
+        src_data: &str,
+        column: usize,
+        dst_row: &mut R,
+    ) -> Result<(), Self::DeserializeError> {
+        let _ = (src_data, column, dst_row);
+        unimplemented!()
+    }
+}
+
 /// The primary trait for the spreadsheet viewer.
 // TODO: When lifetime for `'static` is stabilized; remove the `static` bound.
 pub trait RowViewer<R>: 'static {
@@ -18,6 +58,12 @@ pub trait RowViewer<R>: 'static {
             &" 0 1 2 3 4 5 6 7 8 91011121314151617181920212223242526272829303132"
                 [(column % 10 * 2).pipe(|x| x..x + 2)],
         )
+    }
+
+    /// Tries to create a codec for the row (de)serialization. If this returns `Some`, it'll use
+    /// the system clipboard for copy/paste operations.
+    fn try_create_codec(&mut self) -> Option<impl RowCodec<R>> {
+        None::<()>
     }
 
     /// Returns the rendering configuration for the column.

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -7,17 +7,17 @@ use tap::prelude::Pipe;
 /// A trait for encoding/decoding row data. Any valid UTF-8 string can be used for encoding,
 /// however, as csv is used for clipboard operations, it is recommended to serialize data in simple
 /// string format as possible.
-pub trait RowCodec<'vwr, R> {
+pub trait RowCodec<R> {
     type DeserializeError;
 
     /// Tries encode column data of given row into a string. As the cell for CSV row is already
     /// occupied, if any error or unsupported data is found for that column, just empty out the
     /// destination string buffer.
-    fn encode_column(&self, src_row: &R, column: usize, dst: &mut String);
+    fn encode_column(&mut self, src_row: &R, column: usize, dst: &mut String);
 
     /// Tries decode column data from a string into a row.
     fn decode_column(
-        &self,
+        &mut self,
         src_data: &str,
         column: usize,
         dst_row: &mut R,
@@ -25,16 +25,16 @@ pub trait RowCodec<'vwr, R> {
 }
 
 /// A placeholder codec for row viewers that not require serialization.
-impl<'vwr, R> RowCodec<'vwr, R> for () {
+impl<R> RowCodec<R> for () {
     type DeserializeError = ();
 
-    fn encode_column(&self, src_row: &R, column: usize, dst: &mut String) {
+    fn encode_column(&mut self, src_row: &R, column: usize, dst: &mut String) {
         let _ = (src_row, column, dst);
         unimplemented!()
     }
 
     fn decode_column(
-        &self,
+        &mut self,
         src_data: &str,
         column: usize,
         dst_row: &mut R,
@@ -66,10 +66,9 @@ pub trait RowViewer<R>: 'static {
     /// `is_encoding` parameter is provided to determine if we're creating the codec as encoding
     /// mode or decoding mode.
     ///
-    /// NOTE: Encoder and decoder traits are intentionally not separated to clarify that to qualify
-    /// system clipboard/string serialization support, both features should be implemented. For any
-    /// required optimization, use `is_encoding` flag to create different variant for different
-    /// mode. It is guaranteed that the codec will be used only for one mode at a time.
+    /// It is just okay to choose not to implement both encoding and decoding; returning `None`
+    /// conditionally based on `is_encoding` parameter is also valid. It is guaranteed that created
+    /// codec will be used only for the same mode during its lifetime.
     fn try_create_codec(&mut self, is_encoding: bool) -> Option<impl RowCodec<R>> {
         let _ = is_encoding;
         None::<()>


### PR DESCRIPTION
This pull request includes several commits that add new features and improvements to the codebase. The commits include:

- The addition of a `RowCodec` trait for serde support in the viewer module.

- Work in progress on defining clipboard policies and data types in the draw module.

- The implementation of exporting to the system clipboard in the draw module.

- The implementation of a TSV parser in the util module.

- The implementation of clipboard support in the draw module.

- Miscellaneous changes to resolve warnings.

The patches included in this pull request show the addition of system clipboard support and a new trait item called `Codec`. The version number has also been updated to 0.3.1.

Overall, this pull request adds functionality related to system clipboard support and improves the codebase with the addition of a TSV parser and other enhancements.