### PR TITLE
draw: improve table styling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod draw;
 pub mod viewer;
 
-pub use draw::Renderer;
+pub use draw::{Renderer, Style};
 pub use viewer::{RowViewer, UiAction};
 
 /// You may want to sync egui version with this crate.


### PR DESCRIPTION
# Changes

- Add `Style` struct to customize internal rendering items
- Change default selection visuals to pale blue background from previous orange borders.

# Further TODOs

- Extract more customization options to Style struct.

