### PR TITLE
draw: add single click edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [0.5.0] 
+
+### Added
+
+- New style flag to control editor behavior
+  - 
+
+### Removed
+
+- `viewer::TrivialConfig` was removed.
+  - Configs are integrated inside the `Style` of renderer. 
+
 ## [0.4.1] - 2024-12-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning].
 ### Added
 
 - New style flag to control editor behavior
-  - 
+  - `Style::single_click_edit_mode`: Make single click available to start edit mode.
 
 ### Removed
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -232,6 +232,7 @@ impl RowViewer<Row> for Viewer {
 struct DemoApp {
     table: egui_data_table::DataTable<Row>,
     viewer: Viewer,
+    style_override: egui_data_table::Style,
 }
 
 impl Default for DemoApp {
@@ -262,6 +263,7 @@ impl Default for DemoApp {
                 hotkeys: Vec::new(),
                 row_protection: false,
             },
+            style_override: Default::default(),
         }
     }
 }
@@ -307,6 +309,12 @@ impl eframe::App for DemoApp {
                         "If checked, any rows `Is Student` marked \
                         won't be deleted or overwritten by UI actions.",
                     );
+
+                ui.checkbox(
+                    &mut self.style_override.single_click_edit_mode,
+                    "Single Click Edit",
+                )
+                .on_hover_text("If checked, cells will be edited with a single click.");
             })
         });
 
@@ -329,10 +337,10 @@ impl eframe::App for DemoApp {
             });
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.add(egui_data_table::Renderer::new(
-                &mut self.table,
-                &mut self.viewer,
-            ));
+            ui.add(
+                egui_data_table::Renderer::new(&mut self.table, &mut self.viewer)
+                    .with_style(self.style_override),
+            );
         });
     }
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -22,7 +22,7 @@ mod tsv;
 
 /// Style configuration for the table.
 // TODO: Implement more style configurations.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct Style {
     /// Background color override for selection. Default uses `visuals.selection.bg_fill`.
@@ -40,6 +40,10 @@ pub struct Style {
 
     /// If specify this as [`None`], the heterogeneous row height will be used.
     pub table_row_height: Option<f32>,
+
+    /// When enabled, single click on a cell will start editing mode. Default is `false` where
+    /// double action(click 1: select, click 2: edit) is required.
+    pub single_click_edit_mode: bool,
 }
 
 /* ------------------------------------------ Rendering ----------------------------------------- */
@@ -543,7 +547,9 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
                     s.cci_sel_update(linear_index);
                 }
 
-                if resp.clicked_by(PointerButton::Primary) && is_interactive_cell {
+                if resp.clicked_by(PointerButton::Primary)
+                    && (self.style.single_click_edit_mode || is_interactive_cell)
+                {
                     response_consumed = true;
                     commands.push(Command::CcEditStart(
                         row_id,

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -215,11 +215,6 @@ pub trait RowViewer<R>: 'static {
         self::default_hotkeys(context)
     }
 
-    /// Get trivial configurations for renderer.
-    fn trivial_config(&mut self) -> TrivialConfig {
-        Default::default()
-    }
-
     /// If you want to keep UI state on storage(i.e. persist over sessions), return true from this
     /// function.
     #[cfg(feature = "persistency")]
@@ -381,25 +376,5 @@ pub fn default_hotkeys(context: &UiActionContext) -> Vec<(KeyboardShortcut, UiAc
             (none, Key::Home, UiAction::NavTop),
             (none, Key::End, UiAction::NavBottom),
         ])
-    }
-}
-
-/* ---------------------------------------- Configuration --------------------------------------- */
-
-#[derive(Clone, Debug)]
-pub struct TrivialConfig {
-    /// If specify this as [`None`], the heterogeneous row height will be used.
-    pub table_row_height: Option<f32>,
-
-    /// Maximum number of undo history. This is applied when actual action is performed.
-    pub max_undo_history: usize,
-}
-
-impl Default for TrivialConfig {
-    fn default() -> Self {
-        Self {
-            table_row_height: None,
-            max_undo_history: 100,
-        }
     }
 }


### PR DESCRIPTION
### Added

- New style flag to control editor behavior
  - `Style::single_click_edit_mode`: Make single click available to start edit mode.

### Removed

- `viewer::TrivialConfig` was removed.
  - Configs are integrated inside the `Style` of renderer. 