### PR TITLE
Commit the edit when clicking outside the table.

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -781,6 +781,9 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
                 s.cci_has_focus = true;
             } else if resp.clicked_elsewhere() {
                 s.cci_has_focus = false;
+                if s.is_editing() {
+                    commands.push(Command::CcCommitEdit)
+                }
             }
         }
 


### PR DESCRIPTION
Before:
https://github.com/user-attachments/assets/ac2c4834-95ff-4cc9-8bf6-b4e298397297

After:
https://github.com/user-attachments/assets/14fdc905-e325-4729-9975-fbbd4e6b70e5


IMHO this improves usability of the table.