### PR TITLE
Sort indicator improvements 1

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,6 +1,6 @@
 use std::mem::{replace, take};
 
-use egui::{Align, Color32, Event, Label, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke, StrokeKind, Widget};
+use egui::{Align, Color32, Event, Label, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke, StrokeKind};
 use egui_extras::Column;
 use tap::prelude::{Pipe, Tap};
 
@@ -170,7 +170,11 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
                     let vis_col = VisColumnPos(vis_col);
                     let mut painter = None;
                     let (col_rect, resp) = h.col(|ui| {
-                        ui.horizontal_centered(|ui| {
+                        egui::Sides::new().show(ui, |ui| {
+                            ui.add(Label::new(viewer.column_name(col.0))
+                                .selectable(false)
+                            );
+                        }, |ui|{
                             if let Some(pos) = s.sort().iter().position(|(c, ..)| c == &col) {
                                 let is_asc = s.sort()[pos].1 .0 as usize;
 
@@ -186,10 +190,6 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
                                 // so that the columns don't resize when sorted.
                                 ui.add(Label::new(RichText::new(" ".repeat(max_sort_indicator_width)).monospace()).selectable(false));
                             }
-
-                            egui::Label::new(viewer.column_name(col.0))
-                                .selectable(false)
-                                .ui(ui);
                         });
 
                         painter = Some(ui.painter().clone());

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,9 +1,6 @@
 use std::mem::{replace, take};
 
-use egui::{
-    Align, Color32, Event, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke,
-    StrokeKind, Widget,
-};
+use egui::{Align, Color32, Event, Label, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke, StrokeKind, Widget};
 use egui_extras::Column;
 use tap::prelude::{Pipe, Tap};
 
@@ -183,7 +180,11 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
                                         .monospace(),
                                 );
                             } else {
-                                ui.monospace(" ");
+                                // calculate the maximum width for the sort indicator
+                                let max_sort_indicator_width = (s.num_columns() + 1).to_string().len() + 1;
+                                // when the sort indicator is present, create a label the same size as the sort indicator
+                                // so that the columns don't resize when sorted.
+                                ui.add(Label::new(RichText::new(" ".repeat(max_sort_indicator_width)).monospace()).selectable(false));
                             }
 
                             egui::Label::new(viewer.column_name(col.0))


### PR DESCRIPTION
* fixes the length of the placeholder which was incorrect and caused columns to resize horizontally when sorted.
* makes the sort indicator and placeholder non-selectable.
* moves the sort indicator and placeholder to the right to align the row header with the data in the rows beneath.

Video before:
https://github.com/user-attachments/assets/d7605d15-aa9b-41c4-b2d2-5c2eb1bfb98e

Video after:
https://github.com/user-attachments/assets/8ff7bd93-b849-4f75-8b4f-279024ff8d9d



