### PR TITLE
Extend the viewer API so that row modifications can be tracked.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -247,6 +247,18 @@ impl RowViewer<Row> for Viewer {
         info!("highlight {:?}", highlighted);
         info!("unhighlight {:?}", unhighlighted);
     }
+
+    fn on_row_updated(&mut self, row_index: usize, row: &Row) {
+        println!("row updated. row_id: {}, values: {:?}", row_index, row);
+    }
+    
+    fn on_row_inserted(&mut self, row_index: usize, row: &Row) {
+        println!("row inserted. row_id: {}, values: {:?}", row_index, row);
+    }
+
+    fn on_row_removed(&mut self, row_index: usize, row: &Row) {
+        println!("row removed. row_id: {}, values: {:?}", row_index, row);
+    }
 }
 
 /* ------------------------------------------ View Loop ----------------------------------------- */

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -248,8 +248,8 @@ impl RowViewer<Row> for Viewer {
         info!("unhighlight {:?}", unhighlighted);
     }
 
-    fn on_row_updated(&mut self, row_index: usize, row: &Row) {
-        println!("row updated. row_id: {}, values: {:?}", row_index, row);
+    fn on_row_updated(&mut self, row_index: usize, new_row: &Row, old_row: &Row) {
+        println!("row updated. row_id: {}, new_row: {:?}, old_row: {:?}", row_index, new_row, old_row);
     }
     
     fn on_row_inserted(&mut self, row_index: usize, row: &Row) {

--- a/src/draw/state.rs
+++ b/src/draw/state.rs
@@ -1047,7 +1047,9 @@ impl<R> UiState<R> {
             Command::SetRowValue(row_id, value) => {
                 self.cc_num_frame_from_last_edit = 0;
                 table.dirty_flag = true;
-                table.rows[row_id.0] = vwr.clone_row(value);
+                table.rows[row_id.0] = vwr.clone_row(value); 
+
+                vwr.on_row_updated(row_id.0, &table.rows[row_id.0]);
             }
             Command::SetCells { slab, values } => {
                 self.cc_num_frame_from_last_edit = 0;
@@ -1056,22 +1058,35 @@ impl<R> UiState<R> {
                 for (row, col, value_id) in values.iter() {
                     vwr.set_cell_value(&slab[value_id.0], &mut table.rows[row.0], col.0);
                 }
+
+                let modified_row_indexes = values.iter().map(|(row, _col, _value_id) |row.0).dedup().collect::<Vec<_>>();
+                for row_index in modified_row_indexes {
+                    vwr.on_row_updated(row_index, &mut table.rows[row_index]);
+                }
             }
             Command::InsertRows(pos, values) => {
-                self.cc_dirty = true; // It invalidates all current `RowId` occurences.
+                self.cc_dirty = true; // It invalidates all current `RowId` occurrences.
                 table.dirty_flag = true;
 
                 table
                     .rows
                     .splice(pos.0..pos.0, values.iter().map(|x| vwr.clone_row(x)));
-
-                self.queue_select_rows((pos.0..pos.0 + values.len()).map(RowIdx));
+                let range = pos.0..pos.0 + values.len();
+                
+                for row_index in range.clone() {
+                    vwr.on_row_inserted(row_index, &mut table.rows[row_index]);
+                }
+                self.queue_select_rows(range.map(RowIdx));
             }
             Command::RemoveRow(values) => {
                 debug_assert!(values.windows(2).all(|x| x[0] < x[1]));
-                self.cc_dirty = true; // It invalidates all current `RowId` occurences.
+                self.cc_dirty = true; // It invalidates all current `RowId` occurrences.
                 table.dirty_flag = true;
 
+                for row_index in values.iter() {
+                    vwr.on_row_removed(row_index.0, &mut table.rows[row_index.0]);
+                }
+                
                 let mut index = 0;
                 table.rows.retain(|_| {
                     let idx_now = index.tap(|_| index += 1);

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -245,8 +245,8 @@ pub trait RowViewer<R>: 'static {
     }
     
     /// Called when a row is updated, including when undoing/redoing
-    fn on_row_updated(&mut self, row_index: usize, row: &R) {
-        let (_, _) = (row_index, row);
+    fn on_row_updated(&mut self, row_index: usize, new_row: &R, old_row: &R) {
+        let (_, _, _) = (row_index, new_row, old_row);
     }
 
     /// Called when a row has been inserted, including when undoing/redoing

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -243,6 +243,21 @@ pub trait RowViewer<R>: 'static {
     fn on_highlight_change(&mut self, highlighted: &[&R], unhighlighted: &[&R]) {
         let (_, _) = (highlighted, unhighlighted);
     }
+    
+    /// Called when a row is updated, including when undoing/redoing
+    fn on_row_updated(&mut self, row_index: usize, row: &R) {
+        let (_, _) = (row_index, row);
+    }
+
+    /// Called when a row has been inserted, including when undoing/redoing
+    fn on_row_inserted(&mut self, row_index: usize, row: &R) {
+        let (_, _) = (row_index, row);
+    }
+
+    /// Called when a row has been removed, including when undoing/redoing
+    fn on_row_removed(&mut self, row_index: usize, row: &R) {
+        let (_, _) = (row_index, row);
+    }
 
     /// Return hotkeys for the current context.
     fn hotkeys(&mut self, context: &UiActionContext) -> Vec<(egui::KeyboardShortcut, UiAction)> {


### PR DESCRIPTION
In my app, I need to know when changes to the rows have occurred so that actions, can be performed.  Such actions include:

1) placing a 'modified' indicator in the document's tab.
2) sending changes to a back-end.

Here's a video of it in action (480p due to 10MB file size limit)

https://github.com/user-attachments/assets/21edac1b-eab5-4396-af54-02b49a4fbbd3

High-res version (you-tube): https://www.youtube.com/watch?v=TeskTW-r-tk

main changes are the addition of the follow additions to the Viewer trait.

```
    fn on_row_updated(&mut self, row_index: usize, row: &R) { ... }
    fn on_row_inserted(&mut self, row_index: usize, row: &R) { ... }
    fn on_row_removed(&mut self, row_index: usize, row: &R) { ... }
```

This is a non-breaking change.

I tested it to the best of my ability, but please review the changes in case I missed something.