### PR TITLE
Prevent a new row from being inserted when the table is empty and row insertion is disabled.

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -75,7 +75,7 @@ impl<R, V: RowViewer<R>> egui::Widget for Renderer<'_, R, V> {
 
 impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
     pub fn new(table: &'a mut DataTable<R>, viewer: &'a mut V) -> Self {
-        if table.rows.is_empty() {
+        if table.rows.is_empty() && viewer.allow_row_insertions() {
             table.push(viewer.new_empty_row_for(EmptyRowCreateContext::InsertNewLine));
         }
 


### PR DESCRIPTION
I missed this in #34 and #38 because I was always working with tables that had at least one row.

You can test this in the 'partially_editable' example as follows:

1) uncheck 'enable row insertion'
2) check 'enable row deletion'
3) delete all rows. - observe that no new empty row is created.
4) check enable row insertion - observe that a new empty row is immediately inserted.
