### PR TITLE
Expose auto shrink & scroll bar visibility.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, iter::repeat_with};
 
 use egui::{Response, Sense, Widget};
+use egui::scroll_area::ScrollBarVisibility;
 use egui_data_table::{
     viewer::{default_hotkeys, CellWriteContext, DecodeErrorBehavior, RowCodec, UiActionContext},
     RowViewer,
@@ -255,6 +256,7 @@ struct DemoApp {
     table: egui_data_table::DataTable<Row>,
     viewer: Viewer,
     style_override: egui_data_table::Style,
+    scroll_bar_always_visible: bool,
 }
 
 impl Default for DemoApp {
@@ -287,6 +289,7 @@ impl Default for DemoApp {
                 row_protection: false,
             },
             style_override: Default::default(),
+            scroll_bar_always_visible: false,
         }
     }
 }
@@ -349,6 +352,11 @@ impl eframe::App for DemoApp {
                         "Auto-shrink Y",
                     );
 
+                    ui.checkbox(
+                        &mut self.scroll_bar_always_visible,
+                        "Scrollbar always visible",
+                    );
+
                     if ui.button("Shuffle Rows").clicked() {
                         fastrand::shuffle(&mut self.table);
                     }
@@ -375,6 +383,17 @@ impl eframe::App for DemoApp {
             });
 
         egui::CentralPanel::default().show(ctx, |ui| {
+            match self.scroll_bar_always_visible {
+                true => {
+                    ui.style_mut().spacing.scroll = egui::style::ScrollStyle::solid();
+                    self.style_override.scroll_bar_visibility = ScrollBarVisibility::AlwaysVisible;
+                },
+                false => {
+                    ui.style_mut().spacing.scroll = egui::style::ScrollStyle::floating();
+                    self.style_override.scroll_bar_visibility = ScrollBarVisibility::VisibleWhenNeeded;
+                }
+            };
+
             ui.add(
                 egui_data_table::Renderer::new(&mut self.table, &mut self.viewer)
                     .with_style(self.style_override),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -340,6 +340,15 @@ impl eframe::App for DemoApp {
                     )
                     .on_hover_text("If checked, cells will be edited with a single click.");
 
+                    ui.checkbox(
+                        &mut self.style_override.auto_shrink.x,
+                        "Auto-shrink X",
+                    );
+                    ui.checkbox(
+                        &mut self.style_override.auto_shrink.y,
+                        "Auto-shrink Y",
+                    );
+
                     if ui.button("Shuffle Rows").clicked() {
                         fastrand::shuffle(&mut self.table);
                     }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -13,6 +13,7 @@ use self::state::*;
 
 use format as f;
 use std::sync::Arc;
+use egui::scroll_area::ScrollBarVisibility;
 
 pub(crate) mod state;
 mod tsv;
@@ -58,6 +59,9 @@ pub struct Style {
 
     /// See [`ScrollArea::auto_shrink`] for details.
     pub auto_shrink: Vec2b,
+
+    /// See ['ScrollArea::ScrollBarVisibility`] for details.
+    pub scroll_bar_visibility: ScrollBarVisibility,
 }
 
 /* ------------------------------------------ Rendering ----------------------------------------- */
@@ -190,6 +194,7 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
             .cell_layout(egui::Layout::default().with_cross_align(self.style.cell_align))
             .max_scroll_height(f32::MAX)
             .auto_shrink(self.style.auto_shrink)
+            .scroll_bar_visibility(self.style.scroll_bar_visibility)
             .sense(Sense::click_and_drag().tap_mut(|s| s.set(Sense::FOCUSABLE, true)))
             .header(20., |mut h| {
                 h.col(|_ui| {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,6 +1,6 @@
 use std::mem::{replace, take};
 
-use egui::{Align, Color32, Event, Label, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke, StrokeKind};
+use egui::{Align, Color32, Event, Label, Layout, PointerButton, Rect, Response, RichText, Sense, Stroke, StrokeKind, Vec2b};
 use egui_extras::Column;
 use tap::prelude::{Pipe, Tap};
 
@@ -55,6 +55,9 @@ pub struct Style {
     /// Color to use for the stroke above/below focused row.
     /// If `None`, defaults to a darkened `warn_fg_color`.
     pub focused_row_stroke: Option<egui::Color32>,
+
+    /// See [`ScrollArea::auto_shrink`] for details.
+    pub auto_shrink: Vec2b,
 }
 
 /* ------------------------------------------ Rendering ----------------------------------------- */
@@ -186,6 +189,7 @@ impl<'a, R, V: RowViewer<R>> Renderer<'a, R, V> {
             .striped(true)
             .cell_layout(egui::Layout::default().with_cross_align(self.style.cell_align))
             .max_scroll_height(f32::MAX)
+            .auto_shrink(self.style.auto_shrink)
             .sense(Sense::click_and_drag().tap_mut(|s| s.set(Sense::FOCUSABLE, true)))
             .header(20., |mut h| {
                 h.col(|_ui| {


### PR DESCRIPTION
My requirement is to have a table that takes up the whole space of the container and that has scrollbars in a more useful place, and to have the table column dividers extend vertically to the bottom of the container.

This is most noticable when the table doesn't have many rows. (i.e. 10, not 10,000 in the demo app).

This PR also allows modification of x/y auto-shrink settings and scrollbar visibility in the demo example via the 'flags' menu.

Without:

![image](https://github.com/user-attachments/assets/9e4a2008-7d42-4566-9a34-d9a1371de6d8)

With:

![image](https://github.com/user-attachments/assets/1411e979-760e-442a-9884-7c410bc1789b)
