### PR TITLE
Expand demo: 'Has modifications'

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -347,6 +347,20 @@ impl eframe::App for DemoApp {
             })
         });
 
+        egui::TopBottomPanel::bottom("bottom_panel").show(ctx, |ui| {
+            egui::Sides::new().show(ui, |_ui| {
+            }, |ui|{
+                let mut has_modifications = self.table.has_user_modification();
+                ui.add_enabled(false, egui::Checkbox::new(&mut has_modifications, "Has modifications"));
+
+                ui.add_enabled_ui(has_modifications, |ui| {
+                    if ui.button("Clear").clicked() {
+                        self.table.clear_user_modification_flag();
+                    }
+                });
+            });
+        });
+        
         egui::SidePanel::left("Hotkeys")
             .default_width(500.)
             .show(ctx, |ui| {

--- a/examples/partially_editable.rs
+++ b/examples/partially_editable.rs
@@ -210,6 +210,21 @@ impl eframe::App for DemoApp {
                 ui.checkbox(&mut self.viewer.enable_row_deletion, "Enable Row Deletion");
             });
         });
+
+        egui::TopBottomPanel::bottom("bottom_panel").show(ctx, |ui| {
+            egui::Sides::new().show(ui, |_ui| {
+            }, |ui|{
+                let mut has_modifications = self.table.has_user_modification();
+                ui.add_enabled(false, egui::Checkbox::new(&mut has_modifications, "Has modifications"));
+
+                ui.add_enabled_ui(has_modifications, |ui| {
+                    if ui.button("Clear").clicked() {
+                        self.table.clear_user_modification_flag();
+                    }
+                });
+            });
+        });
+
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.add(egui_data_table::Renderer::new(
                 &mut self.table,


### PR DESCRIPTION
This PR adds a 'Has modifications' checkbox and button to clear the state to the demo and partially_editable examples.  The 'clear' button is only enabled where there are modifications.

This helps users experiment with the API and tables and highlights functionality that might otherwise go un-noticed.

![image](https://github.com/user-attachments/assets/f7c14df7-f7cd-4146-8aa5-aae1ef0f601d)
