### PR TITLE
Fixed missing call to `on_highlight_cell`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Missing call to `on_highlight_cell`. It was added to the API in 0.6.2 but was never called. 
+
 ## [0.7.0]
 
 ### Added

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -84,6 +84,11 @@ impl RowCodec<Row> for Codec {
 /* ------------------------------------ Viewer Implementation ----------------------------------- */
 
 impl RowViewer<Row> for Viewer {
+
+    fn on_highlight_cell(&mut self, row: &Row, column: usize) {
+        println!("cell highlighted: row: {:?}, column: {}", row, column);
+    }
+
     fn try_create_codec(&mut self, _: bool) -> Option<impl RowCodec<Row>> {
         Some(Codec)
     }

--- a/src/draw/state.rs
+++ b/src/draw/state.rs
@@ -957,6 +957,15 @@ impl<R> UiState<R> {
             Command::CcSetSelection(sel) => {
                 if !sel.is_empty() {
                     self.cc_interactive_cell = sel[0].0;
+                    
+                    let (ic_r, ic_c) = self.cc_interactive_cell.row_col(self.p.vis_cols.len());
+                    let row_id = self.cc_rows[ic_r.0];
+
+                    let idx = self.vis_cols()[ic_c.0];
+
+                    let row = &table.rows[row_id.0];
+                        
+                    vwr.on_highlight_cell(row, idx.0);
                 }
 
                 let (highlighted, unhighlighted) = self.get_highlight_changes(table, &sel);


### PR DESCRIPTION
It was added to the API in 0.6.2 but was never called.

Of note, it wasn't clear whether the API wanted a 'column index' or a 'column position'.  it's still not clear in the API.

Recommend renaming all instances to `column: usize` to `column_index: usize` or `column_position: usize` so that is is 100% clear.

This PR was made during a livestream, here: https://youtube.com/live/eoSBbnU-Bcw (2:12:18 - 2:55:16)
