### PR TITLE
Fix on highlight change 1

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -6,7 +6,6 @@ use egui_data_table::{
     viewer::{default_hotkeys, CellWriteContext, DecodeErrorBehavior, RowCodec, UiActionContext},
     RowViewer,
 };
-use log::info;
 
 /* ----------------------------------------- Data Scheme ---------------------------------------- */
 
@@ -250,8 +249,8 @@ impl RowViewer<Row> for Viewer {
     }
 
     fn on_highlight_change(&mut self, highlighted: &[&Row], unhighlighted: &[&Row]) {
-        info!("highlight {:?}", highlighted);
-        info!("unhighlight {:?}", unhighlighted);
+        println!("highlight {:?}", highlighted);
+        println!("unhighlight {:?}", unhighlighted);
     }
 
     fn on_row_updated(&mut self, row_index: usize, new_row: &Row, old_row: &Row) {


### PR DESCRIPTION
The `on_highlight_change` API wasn't working how I expected it to, and there was no way for a viewer to work with the current selection, e.g. to perform an action against all the currently selected rows, via a button external to the table itself. 

The API is:

```rust
    /// Called when a row selected/highlighted status changes.
    fn on_highlight_change(&mut self, highlighted: &[&R], unhighlighted: &[&R]) {
        let (_, _) = (highlighted, unhighlighted);
    }
```

To me, it felt like when the selection changed, the impl was supposed to recieve a slice of all the currently highlighted rows and also receive a slice of the rows that are not not highlighted.

What actually happened is you got a slice of exactly 1 row, containing the last highlighted row, you could thus not track the or otherwise obtain the current selection (at least I don't currently see how you could with the results from the API, please correct me if I'm wrong here).

test-case:

0) sort by any column
1) click the 1st row.
2) shift-click the 2nd row.
3) shift-click the 4th row.
4) shift-click the 5th row.
5) click the 7th row.

Results (before this PR):
```
cell highlighted: row: Row("zonked-word-9977", 17, false, C, false), column: 2
highlight [Row("zonked-word-9977", 17, false, C, false)]
unhighlight []

cell highlighted: row: Row("zonked-word-9977", 17, false, C, false), column: 2
highlight [Row("zonked-women-4085", 6, false, B, false)]
unhighlight [Row("zonked-word-9977", 17, false, C, false)]

cell highlighted: row: Row("zonked-word-9977", 17, false, C, false), column: 2
highlight [Row("zonked-woman-1265", 5, true, F, false)]
unhighlight []

cell highlighted: row: Row("zonked-word-9977", 17, false, C, false), column: 2
highlight [Row("zonked-weather-0235", 27, true, C, false)]
unhighlight [Row("zonked-woman-1265", 5, true, F, false)]

highlight [Row("zonked-trains-3427", 20, false, F, false)]
unhighlight [Row("zonked-women-4085", 6, false, B, false), Row("zonked-weather-0235", 27, true, C, false)]
```

Note that the test-case never unhighlights anything in steps 1-4, yet 'unlighted' is non-empty.

Results: (with this pr):

```
cell highlighted: row: Row("zonked-yarn-4018", 21, true, F, false), column: 2
highlight [Row("zonked-yarn-4018", 21, true, F, false)]
unhighlight []
cell highlighted: row: Row("zonked-yarn-4018", 21, true, F, false), column: 2
highlight [Row("zonked-yarn-4018", 21, true, F, false), Row("zonked-yam-7730", 8, true, C, false)]
unhighlight []
cell highlighted: row: Row("zonked-yarn-4018", 21, true, F, false), column: 2
highlight [Row("zonked-yarn-4018", 21, true, F, false), Row("zonked-yam-7730", 8, true, C, false), Row("zonked-vegetable-6778", 19, false, B, false)]
unhighlight []
cell highlighted: row: Row("zonked-yarn-4018", 21, true, F, false), column: 2
highlight [Row("zonked-yarn-4018", 21, true, F, false), Row("zonked-yam-7730", 8, true, C, false), Row("zonked-vegetable-6778", 19, false, B, false), Row("zonked-uncle-7636", 30, true, F, false)]
unhighlight []
cell highlighted: row: Row("zonked-tooth-6413", 18, false, F, false), column: 2
highlight [Row("zonked-tooth-6413", 18, false, F, false)]
unhighlight [Row("zonked-yarn-4018", 21, true, F, false), Row("zonked-yam-7730", 8, true, C, false), Row("zonked-vegetable-6778", 19, false, B, false), Row("zonked-uncle-7636", 30, true, F, false)]
```

Above, note that unhighlight now behaves as expected, since nothing is unhighted though steps 1-4, and that on step 5, all the previous rows that were made by the 2 multi-selections from step 1-4 are returned in `unhighlighted`, and the new single item is returned in `highlighted`

Note, the data is generated randomly by the demo, but what's important is that the highlight and unhighlight slices contain the correct elements.

Here's a video of this PR in action:

https://github.com/user-attachments/assets/20b26e7e-691e-4f8e-bed6-1284462d6035